### PR TITLE
Convert ctrl_pool code to lsst.log

### DIFF
--- a/config/log4cxx.properties
+++ b/config/log4cxx.properties
@@ -4,6 +4,6 @@ log4j.appender.A1.Target=System.err
 log4j.appender.A1.layout=PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%X{PID} %-5p %c: %m%n
 log4j.appender.F1=org.apache.log4j.FileAppender
-log4j.appender.F1.File=jobs.log
+log4j.appender.F1.File=job_${JOBNAME}.log
 log4j.appender.F1.layout=PatternLayout
 log4j.appender.F1.layout.ConversionPattern=%X{PID} %-5p %d{yyyy-MM-ddThh:mm:ss.sss} %c (%X{LABEL})(%F:%L)- %m%n

--- a/python/lsst/ctrl/pool/log.py
+++ b/python/lsst/ctrl/pool/log.py
@@ -4,28 +4,16 @@ import os
 import copyreg
 
 import lsst.log as lsstLog
-import lsst.pex.logging as pexLog
 from lsst.utils import getPackageDir
-
-
 
 def pickleLog(log):
     """Pickle a log
 
-    Drop the log on the floor; we'll get a new default.
-    Assumes that we're always just using the default log,
-    and not modifying it.
+    Assumes that we're always just using the lsst.log default.
     """
-    return pexLog.getDefaultLog, tuple()
-
-
-def pickleLsstLog(log):
-    """Pickle a lsst.log.Log"""
     return lsstLog.Log, tuple()
 
-copyreg.pickle(pexLog.Log, pickleLog)
-copyreg.pickle(pexLog.ScreenLog, pickleLog)
-copyreg.pickle(lsstLog.Log, pickleLsstLog)
+copyreg.pickle(lsstLog.Log, pickleLog)
 
 
 def jobLog(job):
@@ -33,7 +21,8 @@ def jobLog(job):
     if job is None or job == "None":
         return
     machine = os.uname()[1].split(".")[0]
-    pexLog.getDefaultLog().addDestination(job + ".%s.%d" % (machine, os.getpid()))
     packageDir = getPackageDir("ctrl_pool")
+    #   Set the environment variable which names the output file
+    os.environ['JOBNAME'] = job
     lsstLog.configure(os.path.join(packageDir, "config/log4cxx.properties"))
     lsstLog.MDC("PID", os.getpid())

--- a/python/lsst/ctrl/pool/parallel.py
+++ b/python/lsst/ctrl/pool/parallel.py
@@ -15,7 +15,7 @@ import traceback
 import contextlib
 from lsst.pipe.base import CmdLineTask, TaskRunner
 from .pool import startPool, Pool, NODE, abortOnError, setBatchType
-from . import log  # register pickle functions for pex_logging
+from . import log  # register pickle functions for log
 
 __all__ = ["Batch", "PbsBatch", "SlurmBatch", "SmpBatch", "BATCH_TYPES", "BatchArgumentParser",
            "BatchCmdLineTask", "BatchPoolTask", ]
@@ -63,8 +63,9 @@ def processStats():
 
 def printProcessStats():
     """Print the process statistics to the log"""
-    from lsst.pex.logging import getDefaultLog
-    getDefaultLog().info("Process stats for %s: %s" % (NODE, processStats()))
+    from lsst.log import Log
+    log = Log.getDefaultLogger()
+    log.info("Process stats for %s: %s" % (NODE, processStats()))
 
 
 class Batch(object):

--- a/ups/ctrl_pool.table
+++ b/ups/ctrl_pool.table
@@ -1,7 +1,6 @@
 setupRequired(python_future)
 setupRequired(daf_persistence)
 setupRequired(pipe_base)
-setupRequired(pex_logging)
 setupRequired(log)
 setupRequired(utils)
 setupOptional(mpi4py)


### PR DESCRIPTION
Use the default logger from lsst.log to log messages for parallel.py
Remove pickling code and copyreg for pex_logging.Log
Make pickleLog use the isst.log.Log type
Instead of writing to "jobs.log", write to job name + '.log'