### PR TITLE
BatchCmdLineTask: add --noExit to parent command-line

### DIFF
--- a/python/lsst/ctrl/pool/parallel.py
+++ b/python/lsst/ctrl/pool/parallel.py
@@ -477,7 +477,8 @@ class BatchCmdLineTask(CmdLineTask):
         profilePost = "\"\"\", filename=\"profile-" + job + "-%s-%d.dat\" % (os.uname()[1], os.getpid()))"
 
         return ("python -c '" + (profilePre if args.batchProfile else "") + script +
-                (profilePost if args.batchProfile else "") + "' " + shCommandFromArgs(args.leftover))
+                (profilePost if args.batchProfile else "") + "' " + shCommandFromArgs(args.leftover) +
+                " --noExit")
 
     @contextlib.contextmanager
     def logOperation(self, operation, catch=False, trace=True):


### PR DESCRIPTION
DM-4141 introduced a sys.exit call in CmdLineTask which provides a Unix
exit code, but also appears to bring down the MPI layer before it can
finish up. Adding '--noExit' to the command-line that the CmdLineTask
sees disables the sys.exit call, allowing the MPI to finish up nicely.