### PR TITLE
DM-13732: log: flush console log messages

### DIFF
--- a/config/log4cxx.properties
+++ b/config/log4cxx.properties
@@ -1,6 +1,7 @@
 log4j.rootLogger=INFO, A1, F1
 log4j.appender.A1=ConsoleAppender
 log4j.appender.A1.Target=System.err
+log4j.appender.A1.immediateFlush=true
 log4j.appender.A1.layout=PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%X{PID} %-5p %d{yyyy-MM-ddTHH:mm:ss.SSSZ} %c: %m%n
 log4j.appender.F1=org.apache.log4j.FileAppender


### PR DESCRIPTION
Otherwise they get buffered, which means they can hang around and their
position in the console output isn't indicative of when they occurred.