### PR TITLE
DM-2639: {{Standardize primary method names, run/runDataRef, across PipeTasks}}

### DIFF
--- a/python/lsst/ctrl/pool/parallel.py
+++ b/python/lsst/ctrl/pool/parallel.py
@@ -443,7 +443,7 @@ class BatchCmdLineTask(CmdLineTask):
             taskParser.error("Error in task preparation")
 
         setBatchType(batchArgs.batch)
-            
+
         if batchArgs.batch is None:     # don't use a batch system
             sys.argv = [sys.argv[0]] + batchArgs.leftover # Remove all batch arguments
 

--- a/python/lsst/ctrl/pool/test/demoTask.py
+++ b/python/lsst/ctrl/pool/test/demoTask.py
@@ -37,7 +37,7 @@ class DemoTask(BatchPoolTask):
                       visitRef in parsedCmd.id.refList]
         return time*sum(math.ceil(tt/numCores) for tt in numTargets)
 
-    def run(self, visitRef):
+    def runDataRef(self, visitRef):
         """Main entry-point
 
         Only the master node runs this method.  It will dispatch jobs to the
@@ -51,11 +51,11 @@ class DemoTask(BatchPoolTask):
         dataIdList = collections.OrderedDict(sorted(dataIdList.items()))
 
         with self.logOperation("master"):
-            total = pool.reduce(operator.add, self.read, list(dataIdList.values()),
+            total = pool.reduce(operator.add, self.run, list(dataIdList.values()),
                                 butler=visitRef.getButler())
         self.log.info("Total number of pixels read: %d" % (total,))
 
-    def read(self, cache, dataId, butler=None):
+    def run(self, cache, dataId, butler=None):
         """Read image and return number of pixels
 
         Only the slave nodes run this method.


### PR DESCRIPTION
Rename methods according to RFC-352.
Fifteen total repositories with changes.
