### PR TITLE
DM-23330: Doxygen warnings in pipe_base

### DIFF
--- a/doc/main.dox
+++ b/doc/main.dox
@@ -7,7 +7,7 @@ MPI process pool.
 
 This package contains an implementation of a process pool using MPI
 (\ref lsst.ctrl.pool.pool.Pool "lsst.ctrl.pool.pool.Pool"). It also
-contains customisations of \ref lsst.pipe.base.cmdLineTask.CmdLineTask "lsst.pipe.base.CmdLineTask" that make
+contains customisations of [lsst.pipe.base.CmdLineTask"](https://pipelines.lsst.io/py-api/lsst.pipe.base.CmdLineTask.html) that make
 it simple to either run the Task in parallel over multiple nodes
 (\ref lsst.ctrl.pool.parallel.BatchParallelTask "lsst.ctrl.pool.parallel.BatchParallelTask") or to use the
 scatter/gather capabilities of the process pool directly in a Task 

--- a/ups/ctrl_pool.cfg
+++ b/ups/ctrl_pool.cfg
@@ -3,7 +3,7 @@
 import lsst.sconsUtils
 
 dependencies = {
-    "required": ["daf_persistence", "pipe_base",],
+    "required": ["daf_persistence",],
 }
 
 config = lsst.sconsUtils.Configuration(


### PR DESCRIPTION
This PR fixes a build error caused by converting `pipe_base` to a pure-Python package in lsst/pipe_base#184.