### PR TITLE
DM-31530: Forward python logging to lsst.log

### DIFF
--- a/python/lsst/ctrl/pool/log.py
+++ b/python/lsst/ctrl/pool/log.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import copyreg
 import lsst.log as lsstLog
@@ -24,3 +25,9 @@ def jobLog(job):
     os.environ['JOBNAME'] = job
     lsstLog.configure(os.path.join(packageDir, "config/log4cxx.properties"))
     lsstLog.MDC("PID", os.getpid())
+
+    # Forward python logging to lsst.log
+    lgr = logging.getLogger()
+    lsst_log_level = lsstLog.getDefaultLogger().getEffectiveLevel()
+    lgr.setLevel(lsstLog.LevelTranslator.lsstLog2logging(lsst_log_level))
+    lgr.addHandler(lsstLog.LogHandler())


### PR DESCRIPTION
This is important now that Task logging uses python logging.
Previously no python log output was appearing.