### PR TITLE
DM-35917: Disable flake8 testing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,5 +9,4 @@ exclude =
   tests/.tests
 
 [tool:pytest]
-addopts = --flake8
 flake8-ignore = E133 E226 E228 N802 N803 N806 N812 N813 N815 N816 W504


### PR DESCRIPTION
flake8 testing within pytest forces the code to be imported and
that no longer works now that pipe_base has removed Gen2 code.